### PR TITLE
fix(components): allow copy mob names with special chars

### DIFF
--- a/src/components/CopyButton.astro
+++ b/src/components/CopyButton.astro
@@ -8,15 +8,9 @@ const { textToCopy, className = "" } = Astro.props;
 ---
 
 <button
-  class={`absolute right-2 top-2 z-10 rounded-md bg-gray-800/80 p-1.5 text-white opacity-100 transition-all duration-200 hover:bg-gray-700 ${className}`}
-  onclick={`
-    navigator.clipboard.writeText('${textToCopy}').then(() => {
-      this.innerHTML = '<svg class="h-3 w-3" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" /></svg>';
-      setTimeout(() => {
-        this.innerHTML = '<svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>';
-      }, 1000);
-    });
-  `}
+  class={`copy-button absolute right-2 top-2 z-10 rounded-md bg-gray-800/80 p-1.5 text-white opacity-100 transition-all duration-200 hover:bg-gray-700 ${className}`}
+  data-text-to-copy={textToCopy}
+  onclick="copyToClipboard(this)"
   title="Copy name to clipboard"
 >
   <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -28,3 +22,8 @@ const { textToCopy, className = "" } = Astro.props;
     ></path>
   </svg>
 </button>
+
+<script>
+  import { copyToClipboard } from "../scripts/copyToClipboard";
+  (window as any).copyToClipboard = copyToClipboard;
+</script>

--- a/src/scripts/copyToClipboard.ts
+++ b/src/scripts/copyToClipboard.ts
@@ -1,0 +1,18 @@
+export function copyToClipboard(button: HTMLButtonElement) {
+  const textToCopy = button.dataset.textToCopy;
+  if (!textToCopy) return;
+
+  navigator.clipboard
+    .writeText(textToCopy)
+    .then(() => {
+      const originalHTML = button.innerHTML;
+      button.innerHTML =
+        '<svg class="h-3 w-3" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" /></svg>';
+      setTimeout(() => {
+        button.innerHTML = originalHTML;
+      }, 1000);
+    })
+    .catch((err) => {
+      console.error("Error copying to clipboard:", err);
+    });
+}


### PR DESCRIPTION
This pull request refactors the copy-to-clipboard functionality in the `CopyButton` component to improve maintainability and separation of concerns. The logic for copying text and updating the button UI is moved from inline JavaScript in the component to a dedicated script file, making the code easier to manage and test.

**Refactor and separation of copy logic:**

* Moved the copy-to-clipboard logic from inline JavaScript in `src/components/CopyButton.astro` to a new function `copyToClipboard` in `src/scripts/copyToClipboard.ts`, improving code organization and maintainability. [[1]](diffhunk://#diff-6b465027f92428ecbafa0ff52f7e9afcfc0676ad735c2abd4c77cfec9992e38bR1-R18) [[2]](diffhunk://#diff-82cdf3e95744f74fc0088f2722280f09c3b430caae5df09833c34044cacd606bL11-R13)
* Updated the button in `CopyButton.astro` to use a `data-text-to-copy` attribute and a global `copyToClipboard` function for handling the copy action, instead of embedding the logic directly in the `onclick` attribute.
* Imported and exposed the `copyToClipboard` function globally in the component via a `<script>` tag, enabling the button to call it on click.

**UI and code improvements:**

* Preserved the original button icon and restored it after the copy confirmation icon is shown, using the refactored logic in `copyToClipboard.ts`.
* Added error handling for clipboard copy failures, logging errors to the console for easier debugging.