### PR TITLE
Vercel adapter and video requests with official xml

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,7 +1,7 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import tailwindcss from '@tailwindcss/vite';
-import vercel from "@astrojs/vercel";
+import vercel from '@astrojs/vercel';
 
 // https://astro.build/config
 export default defineConfig({

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,10 +1,12 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
-
 import tailwindcss from '@tailwindcss/vite';
+import vercel from "@astrojs/vercel";
 
 // https://astro.build/config
 export default defineConfig({
+  output: "server",
+  adapter: vercel(),
   vite: {
     plugins: [tailwindcss()]
   }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "astro": "astro"
   },
   "dependencies": {
+    "@astrojs/vercel": "^9.0.5",
     "@tailwindcss/vite": "^4.0.9",
     "astro": "^5.4.0",
     "chart.js": "^4.4.8",

--- a/src/pages/api/streamsRequest.ts
+++ b/src/pages/api/streamsRequest.ts
@@ -1,0 +1,39 @@
+import type { APIRoute } from "astro";
+
+const RSS_FEED = "https://www.youtube.com/feeds/videos.xml?channel_id=UC1B0iXsRUVHFit6dvwnBDlw";
+
+export const GET: APIRoute = async () => {
+  try {
+    const res = await fetch(RSS_FEED);
+    const xml = await res.text();
+    const entries = [...xml.matchAll(/<entry>([\s\S]*?)<\/entry>/g)];
+
+    const videos = entries.map((entry) => {
+      const content = entry[1];
+      const id = (content.match(/<yt:videoId>(.*?)<\/yt:videoId>/) || [])[1] || "";
+      const title = (content.match(/<title>(.*?)<\/title>/) || [])[1] || "";
+
+      return {
+        id,
+        title: title
+          .replace(/&amp;/g, "&")
+          .replace(/&lt;/g, "<")
+          .replace(/&gt;/g, ">")
+          .replace(/&#39;/g, "'")
+          .replace(/&quot;/g, '"'),
+        thumbnail: `https://i.ytimg.com/vi/${id}/hqdefault.jpg`,
+        url: `https://www.youtube.com/watch?v=${id}`,
+      };
+    });
+
+    return new Response(JSON.stringify(videos), {
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  } catch (err) {
+    return new Response(JSON.stringify([]), {
+      status: 500,
+    });
+  }
+};

--- a/src/sections/ArchiveSection.astro
+++ b/src/sections/ArchiveSection.astro
@@ -55,27 +55,32 @@ const YOUTUBE_ICON_PATH = "M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.
   </div>
 </section>
 
-<script define:vars={{ RSS_FEED }}>
+<script>
   async function loadVideos() {
     const container = document.getElementById("videos-container");
 
     if (!container) return;
 
     try {
-      const proxy = `https://api.allorigins.win/raw?url=${encodeURIComponent(RSS_FEED)}`;
-
-      const res = await fetch(proxy, {
+      // YOUR STATIC ASTRO API ROUTE
+      const res = await fetch("/api/streamsRequest", {
         cache: "no-store",
       });
 
-      const xmlText = await res.text();
+      if (!res.ok) {
+        throw new Error("Failed request");
+      }
 
-      const parser = new DOMParser();
-      const xml = parser.parseFromString(xmlText, "text/xml");
+      type Video = {
+        id: string;
+        title: string;
+        thumbnail: string;
+        url: string;
+      };
 
-      const entries = [...xml.querySelectorAll("entry")];
+      const videos: Video[] = await res.json();
 
-      if (!entries.length) {
+      if (!videos.length) {
         container.innerHTML = `
           <div class="text-center text-white/40 py-20 col-span-full">
             <p>No se pudieron cargar los streams.</p>
@@ -83,21 +88,6 @@ const YOUTUBE_ICON_PATH = "M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.
         `;
         return;
       }
-
-      const videos = entries.map((entry) => {
-        const videoId = entry.querySelector("video\\:videoId")?.textContent || entry.querySelector("videoId")?.textContent;
-
-        const title = entry.querySelector("title")?.textContent || "Video";
-
-        const link = entry.querySelector("link")?.getAttribute("href");
-
-        return {
-          id: videoId,
-          title,
-          url: link,
-          thumbnail: `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`,
-        };
-      });
 
       container.innerHTML = videos
         .slice(0, 15)


### PR DESCRIPTION
Features:
+ Add Vercel adapter with dependency "@astrojs/vercel": "^9.0.5"
+ Add serverless /api/streams endpoint that fetches the official YouTube XML feed
+ Keep the site statically rendered except for the /api/streams serverless endpoint

Note:
* Archive stays as a "Soon Section" since it now collides with schems archive.